### PR TITLE
`to_scaled_val` from Rate return Result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "decimal-wad"
 description = "Math for preserving precision floats up to 18 decimal places."
 repository = "https://github.com/hubble-markets/decimal-wad"
 license = "MIT"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2018"
 
 [dependencies]

--- a/src/decimal.rs
+++ b/src/decimal.rs
@@ -187,7 +187,7 @@ where
 
 impl From<Rate> for Decimal {
     fn from(val: Rate) -> Self {
-        Self(val.to_scaled_val())
+        Self(val.to_scaled_val().unwrap())
     }
 }
 

--- a/src/rate.rs
+++ b/src/rate.rs
@@ -58,12 +58,11 @@ impl Rate {
     }
 
     /// Return raw scaled value
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_scaled_val<T>(&self) -> T
+    pub fn to_scaled_val<T>(&self) -> Result<T, DecimalError>
     where
-        T: From<U128>,
+        T: TryFrom<U128>,
     {
-        self.0.into()
+        T::try_from(self.0).map_err(|_| DecimalError::MathOverflow)
     }
 
     /// Create scaled decimal from percent value


### PR DESCRIPTION
`to_scaled_val` in `Rate` impl was using `From` instead of `TryFrom` leading to some incompatibilities in some usage. Now use the same signature as the `Decimal` implementation.